### PR TITLE
Enable SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,29 @@ List your RuuviTag devices' MAC addressess in [ruuvi.yaml](./recipes-ruuvigate/s
 
 Alternatively, you can mount the SD card's `root` filesystem and edit \
 `etc/ruuvigate/ruuvi.yaml`
+
+## Enable SSH connectivity
+You can connect to your RuuviGate with SSH. By default, Public Key Authentication is used. First, generate a public and private key pair with `ssh-keygen`. For example:
+
+```
+~/.ssh$ ssh-keygen -t rsa -f ruuvigate
+```
+
+then copy the _ruuvigate.pub_ **public key** content to RuuviGate's [authorized_keys](./recipes-connectivity/openssh/files/authorized_keys) file. Futhermore, create the following entry to your SSH client's config file:
+
+```
+Host ruuvigate
+     HostName <IP-of-your-RuuviGate>
+     User root
+     Port 13666
+     IdentityFile /home/<your-username>/.ssh/ruuvigate.pub
+```
+
+Opening SSH connection should now work with:
+
+```
+$ ssh ruuvigate
+```
+
+Alternatively, you can mount the SD card's `root` filesystem and edit \
+`home/root/.ssh/authorized_keys`

--- a/recipes-connectivity/openssh/files/sshd.socket
+++ b/recipes-connectivity/openssh/files/sshd.socket
@@ -1,0 +1,11 @@
+[Unit]
+Conflicts=sshd.service
+Wants=sshdgenkeys.service
+
+[Socket]
+ExecStartPre=@BASE_BINDIR@/mkdir -p /var/run/sshd
+ListenStream=13666
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/recipes-connectivity/openssh/files/sshd_config
+++ b/recipes-connectivity/openssh/files/sshd_config
@@ -1,0 +1,118 @@
+#	$OpenBSD: sshd_config,v 1.102 2018/02/16 02:32:40 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Port 13666
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin without-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+Compression no
+ClientAliveInterval 15
+ClientAliveCountMax 4
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,19 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+   file://sshd_config \
+   file://authorized_keys \
+   file://sshd.socket \
+"
+
+do_install:append() {
+    # Replace the default configuration with a custom one
+    rm ${D}${sysconfdir}/ssh/sshd_config
+    install -m 644 ${WORKDIR}/sshd_config ${D}${sysconfdir}/ssh/
+
+    # Create the authorized_keys file to sshd default location
+    install -d ${D}${ROOT_HOME}/.ssh
+    install -m 644 ${WORKDIR}/authorized_keys ${D}${ROOT_HOME}/.ssh/
+}
+
+FILES:${PN}-sshd += "${ROOT_HOME}/.ssh/authorized_keys"

--- a/recipes-core/images/ruuvigate-image.bb
+++ b/recipes-core/images/ruuvigate-image.bb
@@ -5,6 +5,10 @@ inherit features_check
 REQUIRED_MACHINE_FEATURES = "bluetooth"
 REQUIRED_DISTRO_FEATURES = "bluetooth"
 
+# Remove debug-tweaks as it causes unwanted tweaks to sshd_config
+IMAGE_FEATURES:remove = "debug-tweaks"
+IMAGE_FEATURES += "ssh-server-openssh"
+
 IMAGE_INSTALL:append = " \
                 python3 \
                 python3-ruuvigate \


### PR DESCRIPTION
Added `ssh-server-openssh` image feature and `openssh` recipe append files for SSH connectivity using `PubkeyAuthentication` only.